### PR TITLE
Add 3-day minimum release age for mise and Renovate updates

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,8 @@
 [tools]
 node = "24.16.0"
+
+[settings]
+# Ignore tool versions published less than 3 days ago to reduce supply chain
+# attack risk. Only affects fuzzy resolution (e.g. node@24, latest), not the
+# exact pin above — it's here as defense-in-depth for future/npm-backend tools.
+minimum_release_age = "3d"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# Wait 3 days (4320 minutes) after a version is published before installing it,
+# to reduce supply chain attack risk. pnpm 11 already defaults this to 1440
+# (1 day); this raises it to match the Renovate and mise cooldowns.
+minimumReleaseAge: 4320

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,12 @@
 {
   "extends": ["config:recommended"],
   "assignees": ["dangmai"],
+  // Wait 3 days after a version is published before updating, to reduce supply
+  // chain attack risk. timestamp-required (currently Renovate's default, pinned
+  // here explicitly) fails closed: versions whose release timestamp is unknown
+  // are treated as not-yet-aged rather than installed.
+  "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "automergeType": "branch",
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
Dependency-update bots and package managers install new versions almost as soon as they're published, which is exactly the window supply chain attackers exploit — a compromised release typically gets detected and yanked within hours. A short cooldown closes that window cheaply: nearly all smash-and-grab npm attacks are caught well within 3 days, so refusing to install anything newer than that filters out most of them without meaningfully slowing us down.

This adds a 3-day minimum release age in every place that pulls new versions:

- **`renovate.json5`** — `minimumReleaseAge: "3 days"`. Renovate won't even create a branch until a version is 3 days old (`internalChecksFilter` defaults to `strict`), so the existing automerge rules just wait the 3 days and then merge as usual. I also pinned `minimumReleaseAgeBehaviour: "timestamp-required"` explicitly — it's Renovate's current default, but pinning it means a version with no known release timestamp fails closed (treated as not-yet-aged) rather than slipping through.
- **`pnpm-workspace.yaml`** (new) — `minimumReleaseAge: 4320` (3 days, in minutes). pnpm 11 already enforces a 1-day cooldown by default; this raises it to 3 days so the package manager itself applies the same delay as Renovate. Only affects future resolution, so no lockfile change.
- **`mise.toml`** — `[settings] minimum_release_age = "3d"`. This is defense-in-depth: mise only applies the filter to *fuzzy* resolution (`node@24`, `latest`), so it has no effect on the current exact `node = "24.16.0"` pin. It's there to cover future fuzzy versions or any `npm:`-backend tools we add later.

Validated all three: `renovate-config-validator` passes, `pnpm config get minimumReleaseAge` → `4320`, and `mise settings get minimum_release_age` → `3d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)